### PR TITLE
REL-4333 Adapt Oracle patch: add explicit dependency on Config::AutoConf

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -49,6 +49,7 @@ my %CONFIGURE_DEPS = (
     'File::Spec'          => 0,
     'IPC::Cmd'            => 0,
     'base'                => 0,
+    'Config::AutoConf'    => '0.315',
 );
 my %BUILD_DEPS = ();
 


### PR DESCRIPTION
ISSUE:
List::MoreUtils::XS installation fails during perl-venv RPM build:
~~~
[ 1127s] Configuring List-MoreUtils-XS-0.430
[ 1127s] Running Makefile.PL
[ 1127s] Can't locate Config/AutoConf.pm in @INC
~~~

ROOT:
List::MoreUtils::XS depends on both the bundled Config::AutoConf version, and the externally-installed Config::AutoConf version after Oracle's patch. However, Oracle's patch didn't add Config::AutoConf module as dependency to List::MoreUtils::XS inside its Makefile.PL, instead Oracle added perl(Config::AutoConf) as BuildRequires dependency to perl-List-MoreUtils-XS RPM to guarantee that Config::AutoConf module would be installed. Now that we moved all module out of their individual RPMs, this additional layer of dependencies provided by the RPM format is gone, so we have to guarantee that Config::AutoConf will be installed before List::MoreUtils::XS build in some other way - using the native mechanism of Makefile.PL-based Perl modules.

FIX:
- Add explicit dependency onto Config::AutoConf module in Makefile.PL of List::MoreUtils::XS.